### PR TITLE
Fixed a couple of typos and a bootstrap problem in linux

### DIFF
--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -5,7 +5,8 @@ if (php_sapi_name() != "cli") {
 }
 	
 spl_autoload_register(function ($class_name) {
-	include $class_name . ".php";
+	$filename = str_replace('\\', DIRECTORY_SEPARATOR, $class_name) . '.php';
+	include $filename;
 });
 
 

--- a/pChart/pDraw.debug.php
+++ b/pChart/pDraw.debug.php
@@ -291,7 +291,7 @@ class pDraw
 		
 		if($FileName == NULL){ 
 			# Cache control should be done at a higher level
-			header('Content-/type: image/png');
+			header('Content-type: image/png');
 		}
 		imagepng($Picture, $FileName, $Compression, $Filters);		
 		imagedestroy($Picture);

--- a/pChart/pDraw.php
+++ b/pChart/pDraw.php
@@ -3940,7 +3940,7 @@ class pDraw
 			header("Pragma: no-cache");
 		}
 
-		header('Content-/type: image/png');
+		header('Content-type: image/png');
 		imagepng($this->Picture, NULL, $Compression, $Filters);
 	}
 


### PR DESCRIPTION
1. Fixed a typo in pChart/pDraw.debug.php and in pChart/pDraw.php
2. Updated bootstrap.php to work with DIRECTORY_SEPARATOR.
I was getting :
    PHP Warning:  include(pChart\\pDraw.php): failed to open stream: No such file or directory in ---PATH---/pChart2.0-for-PHP7-master/examples/bootstrap.php on line 8

These fixes also needs to be merged with branch 2.2